### PR TITLE
Add Koin integration

### DIFF
--- a/buildSrc/src/main/groovy/shedinja.kotlin-lib-conventions.gradle
+++ b/buildSrc/src/main/groovy/shedinja.kotlin-lib-conventions.gradle
@@ -24,6 +24,12 @@ dependencies {
     detektPlugins libs.detekt.formatting
 }
 
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(8)
+    }
+}
+
 test {
     useJUnitPlatform()
 }

--- a/docs/src/Building.md
+++ b/docs/src/Building.md
@@ -1,0 +1,52 @@
+# Building Shedinja
+
+The Shedinja project is built using a tool named [Gradle](https://gradle.org/). You will need a recent Java Development
+Kit (JDK for short) on your system: you do not need to install Gradle.
+
+You can grab a JDK over at [Adoptium](https://adoptium.net).
+
+## Using gradle
+
+Most tasks will require you to use Gradle. You can run Gradle tasks by using the wrapper scripts (`gradlew` for
+macOS/Linux or `gradlew.bat` for Windows).
+
+```sh
+$ ./gradlew
+```
+
+## Building Shedinja
+
+Shedinja can be built using the `build` task, like so:
+
+```sh
+$ ./gradlew build
+```
+
+This will run all the tests, code analysis tools and produce JAR files that you can then ingest. 
+
+?> We recommend using [our pre-built JAR files](GettingStarted.md#adding-shedinja) instead of compiling Shedinja yourself.
+
+Shedinja is organized in modules. Each module provides either specific functionality (like Koin integration) or can be 
+more complex (like the `shedinja` module, which provides most of the core classes).
+
+## Building the documentation
+
+The documentation website uses custom Gradle tasks. There are two scenarios:
+
+* Building the website
+* Serving the website for previewing it while editing.
+
+For the first case, you can just run:
+
+```sh
+$ ./gradlew buildDocs
+```
+
+For the second case, you will need two separate terminals.
+
+```sh
+# In the first terminal
+$ ./gradlew -t buildDocs
+# In the second terminal
+$ ./gradlew serveDocs
+```

--- a/docs/src/Extensions.md
+++ b/docs/src/Extensions.md
@@ -1,0 +1,135 @@
+# Extensions
+
+Shedinja's core APIs are designed to be quite simple yet flexible. In addition to those, Shedinja also provides more advanced features in the form of extension functions that only use Shedinja's public APIs.
+
+Extensions are all located within the `guru.zoroark.shedinja.extensions` package.
+
+## Injection Factories
+
+?> This extension is experimental.
+
+Many frameworks allow you to either inject a *singleton* (where a single object instance is injected) or a *factory* (where any component that depends on the factory gets its own instance of the object). Factories are very useful for objects like loggers.
+
+Shedinja factories are an extension of Shedinja's system -- in fact, they are implemented entirely with public APIs from Shedinja's core system!
+
+You can create factories using the `putFactory` method within your environment builder or within a module. Factories are injected using the `factory from scope` syntax.
+
+!> Make sure you do not use `by scope()` to retrieve an object that is supposed to be created by a factory!
+
+```kotlin
+class Logger {
+    fun logInfo(message: String) = println("INFO: $message")
+    fun logWarn(message: String) = println("WARN: $message")
+}
+
+class ServiceA(scope: InjectionScope) {
+    private val logger by factory from scope
+
+    fun doSomething() {
+        logger.logInfo("Doing something in A...")
+    }
+}
+
+class ServiceB(scope: InjectionScope) {
+    private val logger by factory from scope
+    private val a by scope()
+
+    fun doSomething() {
+        a.doSomething()
+        logger.logInfo("Doing something in B...")
+    }
+}
+
+val environment = shedinja {
+    putFactory { Logger() }
+
+    put(::ServiceA)
+    put(::ServiceB)
+}
+
+environment.get<ServiceA>().doSomething()
+// INFO: Doing something in A...
+// INFO: Doing something in B...
+```
+
+### Creating objects based on requester
+
+It is possible to create objects based on which component is requesting them. This is useful for giving a logger a name, for example:
+
+```kotlin
+class Logger(private val name: String) {
+    fun logInfo(message: String) = println("($name) INFO: $message")
+    fun logWarn(message: String) = println("($name) WARN: $message")
+}
+
+// ServiceA and ServiceB are the same as before
+
+val environment = shedinja {
+    putFactory { requester -> Logger(requester::class.qualifiedName ?: "<anon>") }
+
+    put(::ServiceA)
+    put(::ServiceB)
+}
+
+environment.get<ServiceA>().doSomething()
+// (org.example.ServiceA) INFO: Doing something in A...
+// (org.example.ServiceB) INFO: Doing something in B...
+```
+
+You can go even further with annotations:
+
+```kotlin
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class LoggerName(val name: String)
+
+private val KClass<*>.loggerName: String
+    get() = findAnnotation<LoggerName>()?.name ?: qualifiedName ?: "<anon>"
+
+class Logger(private val name: String) {
+    fun logInfo(message: String) = println("($name) INFO: $message")
+    fun logWarn(message: String) = println("($name) WARN: $message")
+}
+
+@LoggerName("Custom logger name!")
+class ServiceA(scope: InjectionScope) {
+    private val logger by factory from scope
+
+    fun doSomething() {
+        logger.logInfo("Doing something in A...")
+    }
+}
+
+class ServiceB(scope: InjectionScope) {
+    private val logger by factory from scope
+    private val a by scope()
+
+    fun doSomething() {
+        a.doSomething()
+        logger.logInfo("Doing something in B...")
+    }
+}
+
+val environment = shedinja {
+    putFactory { requester -> Logger(requester::class.loggerName) }
+
+    put(::ServiceA)
+    put(::ServiceB)
+}
+
+environment.get<ServiceA>().doSomething()
+// (Custom logger name!) INFO: Doing something in A...
+// (org.example.ServiceB) INFO: Doing something in B...
+```
+
+### How do factories work?
+
+In a nutshell, *factories* are injected in the environment, and this factory gets invoked when the object is requested. The factory is injected in the environment as a regular singleton.
+
+Factories are objects which implement the functional interface `InjectableFactory<T>` (the Kotlin equivalent for SAMs in Java). Its `make(requester: Any): T` function is invoked when an object is requested.
+
+Factories are injected with an additional qualifier. Because of its generic typing, only including the class would lead to components with the same identifier, which would be `InjectableFactory::class` without qualifiers. In order to avoid this, an `InjectableFactoryOutputTypeQualifer` is used as a qualifier to differentiate between factories. The `outputs` function can also be used as an alias for this qualifier.
+
+The `putFactory` method is in charge of the entire injection process: creating the factory with the correct qualifier and injecting it within a simple `put` call.
+
+On the injection side, the only change is that a wrapper is put around the `scope()` call: instead of the actual type being requested, the corresponding factory is requested when using `factory from scope`. It is then wrapped using the `WrappedReadOnlyProperty` class which executes the factory's `make` method and wrapped *again* within a `SynchronizedLazyPropertyWrapper`. As such, the factory's method is only called once and only when necessary.

--- a/docs/src/KoinIntegration.md
+++ b/docs/src/KoinIntegration.md
@@ -1,0 +1,60 @@
+# Koin Integration
+
+Shedinja allows you to embed Shedinja modules within [Koin v2](https://insert-koin.io/) application. It is compatible both ways: you can inject components from Koin into Shedinja and vice-versa.
+
+!> Koin v3 is not supported. **This functionality abuses internal `@PublishedApi` mechanisms and is experimental.**
+
+## Dependency
+
+You will first need to add a dependency on the `shedinja-koin-v2` module. Make sure you also [have the `shedinja` dependency](/GettingStarted.md#adding-shedinja) as well as [Koin's dependencies](https://insert-koin.io/docs/setup/v2). Shedinja only requires the `koin-core` module for the integration to work. 
+
+<!-- tabs:start -->
+
+#### **Gradle Groovy DSL**
+
+```groovy
+dependencies {
+    implementation 'guru.zoroark.shedinja:shedinja-koin-v2:VERSION'
+}
+```
+
+#### **Gradle Kotlin DSL**
+
+```kotlin
+dependencies {
+    implementation("guru.zoroark.shedinja:shedinja-koin-v2:VERSION")
+}
+```
+
+#### **Maven**
+
+```xml
+<dependency>
+    <groupId>guru.zoroark.shedinja</groupId>
+    <artifactId>shedinja-koin-v2</artifactId>
+    <version>VERSION</version>
+</dependency>
+```
+
+<!-- tabs:end -->
+
+
+## Shedinja modules in Koin apps
+
+Create your modules as you would with regular Koin/Shedinja modules. Within your `KoinApplication` block, add your Shedinja modules using the `shedinjaModules` function:
+
+```kotlin
+val moduleFromShedinja = shedindjaModule {
+    // ...
+}
+
+val moduleFromKoin = module {
+    // ...
+}
+
+val koinApp = startKoin {
+    modules(moduleFromKoin)
+    
+    shedinjaModules(moduleFromShedinja)
+}
+```

--- a/docs/src/KoinIntegration.md
+++ b/docs/src/KoinIntegration.md
@@ -2,11 +2,16 @@
 
 Shedinja allows you to embed Shedinja modules within [Koin v2](https://insert-koin.io/) application. It is compatible both ways: you can inject components from Koin into Shedinja and vice-versa.
 
-!> Koin v3 is not supported. **This functionality abuses internal `@PublishedApi` mechanisms and is experimental.**
+!> This functionality abuses internal `@PublishedApi` mechanisms and is experimental.
 
 ## Dependency
 
-You will first need to add a dependency on the `shedinja-koin-v2` module. Make sure you also [have the `shedinja` dependency](/GettingStarted.md#adding-shedinja) as well as [Koin's dependencies](https://insert-koin.io/docs/setup/v2). Shedinja only requires the `koin-core` module for the integration to work. 
+You will first need to add a dependency on the `shedinja-koin-v2` or `shedinja-koin-v3` module depending of which versino of Koin you want to integrate with. Make sure you also [have the `shedinja` dependency](/GettingStarted.md#adding-shedinja) as well as [Koin's own dependencies](https://insert-koin.io/docs/setup/v2). Shedinja only requires the `koin-core` module for the integration to work.
+
+
+### Koin 2
+
+Relevant functions and classes are provided in the `guru.zoroark.shedinja.koin2` package.
 
 <!-- tabs:start -->
 
@@ -38,6 +43,39 @@ dependencies {
 
 <!-- tabs:end -->
 
+### Koin 3
+
+Relevant functions and classes are provided in the `guru.zoroark.shedinja.koin2` package.
+
+<!-- tabs:start -->
+
+#### **Gradle Groovy DSL**
+
+```groovy
+dependencies {
+    implementation 'guru.zoroark.shedinja:shedinja-koin-v3:VERSION'
+}
+```
+
+#### **Gradle Kotlin DSL**
+
+```kotlin
+dependencies {
+    implementation("guru.zoroark.shedinja:shedinja-koin-v3:VERSION")
+}
+```
+
+#### **Maven**
+
+```xml
+<dependency>
+    <groupId>guru.zoroark.shedinja</groupId>
+    <artifactId>shedinja-koin-v3</artifactId>
+    <version>VERSION</version>
+</dependency>
+```
+
+<!-- tabs:end -->
 
 ## Shedinja modules in Koin apps
 
@@ -54,7 +92,9 @@ val moduleFromKoin = module {
 
 val koinApp = startKoin {
     modules(moduleFromKoin)
-    
+
     shedinjaModules(moduleFromShedinja)
 }
 ```
+
+!> It is not currently possible to add Koin modules to Shedinja environments. If you wish to migrate from Koin to Shedinja, you should do it by progressively turning your Koin modules into Shedinja modules and, once all of your modules have become Shedinja modules, use Shedinja's [environment builders](UsingShedinja.md#environment) and [test facilities](Testing.md).

--- a/docs/src/README.md
+++ b/docs/src/README.md
@@ -2,7 +2,9 @@
 
 Welcome to Shedinja's documentation website!
 
-Shedinja is an easy-to-use dependency injection framework for Kotlin.
+Shedinja is an easy-to-use dependency injection framework for Kotlin, mainly inspired by [Koin](https://insert-koin.io) with the objective of being more flexible and safer.
+
+Shedinja components are easy to test and environments can be ran entirely in parallel. You can automatically test your Shedinja modules for incoherence, cyclic dependencies, completeness and much more.
 
 ```kotlin
 // A simple repository/service/controller sample using Shedinja

--- a/docs/src/UsingShedinja.md
+++ b/docs/src/UsingShedinja.md
@@ -165,8 +165,8 @@ class BanService(scope: InjectionScope) {
 
     private val banRepo: BanRepository by scope()
 
-    fun ban(userToBan: String, requestor: String) {
-        if (requestor in adminUsers && requestor !in permaBannedUsers) {
+    fun ban(userToBan: String, requester: String) {
+        if (requester in adminUsers && requester !in permaBannedUsers) {
             banRepo.ban(userToBan)
         } else {
             error("Not enough permissions!")

--- a/docs/src/_sidebar.md
+++ b/docs/src/_sidebar.md
@@ -1,7 +1,11 @@
+- [Home](/)
+- **About Shedinja**
 - [Getting Started](/GettingStarted.md)
 - [Using Shedinja](/UsingShedinja.md)
 - [Testing Shedinja code](/Testing.md)
+- [Extensions](/Extensions.md)
 - [Koin Integration](/KoinIntegration.md)
+- **Developing**
 - [Building Shedinja](/Building.md)
 - **External links**
 - [📚 GitHub Repository](https://github.com/utybo/Shedinja)

--- a/docs/src/_sidebar.md
+++ b/docs/src/_sidebar.md
@@ -1,6 +1,7 @@
 - [Getting Started](/GettingStarted.md)
 - [Using Shedinja](/UsingShedinja.md)
 - [Testing Shedinja code](/Testing.md)
+- [Koin Integration](/KoinIntegration.md)
 - **External links**
 - [📚 GitHub Repository](https://github.com/utybo/Shedinja)
 - [📦 Packages](https://gitlab.com/utybo/packages/-/packages?search[]=guru%2Fzoroark%2Fshedinja)

--- a/docs/src/_sidebar.md
+++ b/docs/src/_sidebar.md
@@ -2,6 +2,7 @@
 - [Using Shedinja](/UsingShedinja.md)
 - [Testing Shedinja code](/Testing.md)
 - [Koin Integration](/KoinIntegration.md)
+- [Building Shedinja](/Building.md)
 - **External links**
 - [📚 GitHub Repository](https://github.com/utybo/Shedinja)
 - [📦 Packages](https://gitlab.com/utybo/packages/-/packages?search[]=guru%2Fzoroark%2Fshedinja)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,6 +4,7 @@ detekt = "1.18.1"
 junit = "5.7.2"
 dokka = "1.5.0"
 mockk = "1.12.0"
+koin2 = "2.2.3"
 
 [libraries]
 # Plugins
@@ -16,6 +17,8 @@ detekt-gradle = { module = "io.gitlab.arturbosch.detekt:detekt-gradle-plugin", v
 
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version.ref = "kotlin" }
 kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
+
+koin-v2 = { module = "io.insert-koin:koin-core", version.ref = "koin2" }
 
 # Test dependencies
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,6 +5,7 @@ junit = "5.7.2"
 dokka = "1.5.0"
 mockk = "1.12.0"
 koin2 = "2.2.3"
+koin3 = "3.1.2"
 
 [libraries]
 # Plugins
@@ -19,7 +20,7 @@ kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version.re
 kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
 
 koin-v2 = { module = "io.insert-koin:koin-core", version.ref = "koin2" }
-
+koin-v3 = { module = "io.insert-koin:koin-core", version.ref = "koin3" }
 # Test dependencies
 
 kotlin-test-common = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,4 @@
 enableFeaturePreview("VERSION_CATALOGS")
 
 rootProject.name = 'Shedinja'
-include('shedinja', 'shedinja-test', 'shedinja-koin-v2', 'docs')
+include('shedinja', 'shedinja-test', 'shedinja-koin-v2', 'shedinja-koin-v3', 'docs')

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,4 @@
 enableFeaturePreview("VERSION_CATALOGS")
 
 rootProject.name = 'Shedinja'
-include('shedinja', 'shedinja-test', 'docs')
+include('shedinja', 'shedinja-test', 'shedinja-koin-v2', 'docs')

--- a/shedinja-koin-v2/build.gradle
+++ b/shedinja-koin-v2/build.gradle
@@ -1,0 +1,11 @@
+plugins {
+    id 'shedinja.kotlin-lib-conventions'
+}
+
+dependencies {
+    api project(":shedinja")
+    api libs.koin.v2
+    // implementation libs.kotlin.reflect
+
+
+}

--- a/shedinja-koin-v2/src/main/kotlin/guru/zoroark/shedinja/koin2/KoinIntegration.kt
+++ b/shedinja-koin-v2/src/main/kotlin/guru/zoroark/shedinja/koin2/KoinIntegration.kt
@@ -1,0 +1,80 @@
+package guru.zoroark.shedinja.koin2
+
+import guru.zoroark.shedinja.dsl.ShedinjaDsl
+import guru.zoroark.shedinja.environment.Declaration
+import guru.zoroark.shedinja.environment.Identifier
+import guru.zoroark.shedinja.environment.InjectableModule
+import guru.zoroark.shedinja.environment.InjectionScope
+import guru.zoroark.shedinja.environment.Injector
+import guru.zoroark.shedinja.environment.ScopedContext
+import org.koin.core.KoinApplication
+import org.koin.core.definition.BeanDefinition
+import org.koin.core.definition.Definitions
+import org.koin.core.module.Module
+import org.koin.core.qualifier.Qualifier
+import org.koin.dsl.module
+import kotlin.reflect.KProperty
+
+/**
+ * Adds the given Shedinja modules to this Koin application. This process is done transparently for you: you can inject
+ * components from Koin modules into Shedinja modules and vice versa.
+ *
+ * See [toKoinModule] for more information.
+ */
+@ShedinjaDsl
+fun KoinApplication.shedinjaModules(vararg modules: InjectableModule) {
+    modules(modules.map { it.toKoinModule(this@shedinjaModules) })
+}
+
+/**
+ * Turns this Shedinja module into a module that is uses the given Koin application for processing cross-framework
+ * injections.
+ *
+ * Internally, Shedinja injects the components created in this module into the module (thus making Shedinja components
+ * injectable from Koin) and supplies an [InjectionScope] that is backed by the given Koin application object to the
+ * Shedinja object suppliers (thus making Koin components injectable from Koin).
+ *
+ * **NOTE:** This feature abuses the fact that `internal` properties annotated with `@PublishedApi` are effectively
+ * public and can be accessed via reflection without any use of `setAccessible`. Such properties are byte-code public,
+ * although the compiler will raise an error, thus making reflection needed.
+ */
+fun InjectableModule.toKoinModule(app: KoinApplication): Module = module {
+    declarations.forEach {
+        it.applyDeclarationTo(this@module, app)
+    }
+}
+
+private fun <T : Any> Declaration<T>.applyDeclarationTo(module: Module, app: KoinApplication) {
+    val definitions = module.reflectiveAccessTo<Module, HashSet<BeanDefinition<*>>>("getDefinitions")
+    val moduleRootScope = module.reflectiveAccessTo<Module, Qualifier>("getRootScope")
+    definitions.add(
+        Definitions.createSingle(
+            identifier.kclass,
+            null, // TODO translate string qualifiers
+            { supplier(ScopedContext(KoinApplicationBackedScope(app))) },
+            module.makeOptions(false),
+            emptyList(),
+            moduleRootScope
+        )
+    )
+}
+
+private class KoinApplicationBackedScope(private val app: KoinApplication) : InjectionScope {
+    override fun <T : Any> inject(what: Identifier<T>): Injector<T> =
+        KoinApplicatedBackedInjector(what, app)
+}
+
+private class KoinApplicatedBackedInjector<T : Any>(private val identifier: Identifier<T>, private val app: KoinApplication) :
+    Injector<T> {
+    private val value by lazy {
+        app.koin.get(identifier.kclass)
+    }
+
+    override fun getValue(thisRef: Any?, property: KProperty<*>): T = value
+}
+
+private inline fun <reified R, reified T> R.reflectiveAccessTo(propertyName: String): T {
+    return R::class.java.getMethod(propertyName).invoke(this) as T
+}
+
+

--- a/shedinja-koin-v2/src/test/kotlin/guru/zoroark/shedinja/koin2/TestKoinIntegration.kt
+++ b/shedinja-koin-v2/src/test/kotlin/guru/zoroark/shedinja/koin2/TestKoinIntegration.kt
@@ -1,0 +1,107 @@
+package guru.zoroark.shedinja.koin2
+
+import guru.zoroark.shedinja.dsl.put
+import guru.zoroark.shedinja.dsl.shedinjaModule
+import guru.zoroark.shedinja.environment.InjectableModule
+import guru.zoroark.shedinja.environment.InjectionScope
+import guru.zoroark.shedinja.environment.invoke
+import org.junit.jupiter.api.Test
+import org.koin.core.KoinApplication
+import org.koin.core.component.KoinApiExtension
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.dsl.module
+import kotlin.test.assertEquals
+
+
+@OptIn(KoinApiExtension::class)
+class TestKoinIntegration {
+
+    interface IdentityRetriever {
+        fun koinGetAIdentity(): String
+        fun koinComponentAIdentity(): String
+        fun shedinjaAIdentity(): String
+    }
+
+    class KoinGetA {
+        val identity = "I am KoinGetA"
+    }
+
+    class KoinGetB(
+        private val koinGetA: KoinGetA,
+        private val koinComponentA: KoinComponentA,
+        private val shedinjaA: ShedinjaA
+    ) : IdentityRetriever {
+        override fun koinGetAIdentity() = koinGetA.identity + " via KoinGetB"
+        override fun koinComponentAIdentity() = koinComponentA.identity + " via KoinGetB"
+        override fun shedinjaAIdentity() = shedinjaA.identity + " via KoinGetB"
+    }
+
+    class KoinComponentA : KoinComponent {
+        val identity = "I am KoinComponentA"
+    }
+
+    class KoinComponentB: KoinComponent, IdentityRetriever {
+        private val koinGetA: KoinGetA by inject()
+        private val koinComponentA: KoinComponentA by inject()
+        private val shedinjaA: ShedinjaA by inject()
+
+        override fun koinGetAIdentity() = koinGetA.identity + " via KoinComponentB"
+        override fun koinComponentAIdentity() = koinComponentA.identity + " via KoinComponentB"
+        override fun shedinjaAIdentity() = shedinjaA.identity + " via KoinComponentB"
+    }
+
+    class ShedinjaA {
+        val identity = "I am ShedinjaA"
+    }
+
+    class ShedinjaB(scope: InjectionScope): IdentityRetriever {
+        private val koinGetA: KoinGetA by scope()
+        private val koinComponentA: KoinComponentA by scope()
+        private val shedinjaA: ShedinjaA by scope()
+
+        override fun koinGetAIdentity() = koinGetA.identity + " via ShedinjaB"
+        override fun koinComponentAIdentity() = koinComponentA.identity + " via ShedinjaB"
+        override fun shedinjaAIdentity() = shedinjaA.identity + " via ShedinjaB"
+    }
+
+    @Test
+    fun `Test shedinja integration`() {
+        val shedinja = shedinjaModule {
+            put(::ShedinjaA)
+            put(::ShedinjaB)
+        }
+
+        val koinGet = module {
+            single { KoinGetA() }
+            single { KoinGetB(get(), get(), get()) }
+        }
+
+        val koinComponent = module {
+            single { KoinComponentA() }
+            single { KoinComponentB() }
+        }
+
+        val koin = startKoin {
+            modules(koinGet, koinComponent)
+
+            shedinjaModules(shedinja)
+        }.koin
+
+        val retrievers = mapOf(
+            "KoinGetB" to koin.get<KoinGetB>(),
+            "KoinComponentB" to koin.get<KoinComponentB>(),
+            "ShedinjaB" to koin.get<ShedinjaB>()
+        )
+
+        for ((name, obj) in retrievers) {
+            assertEquals("I am KoinGetA via $name", obj.koinGetAIdentity())
+            assertEquals("I am KoinComponentA via $name", obj.koinComponentAIdentity())
+            assertEquals("I am ShedinjaA via $name", obj.shedinjaAIdentity())
+        }
+
+        stopKoin()
+    }
+}

--- a/shedinja-koin-v2/src/test/kotlin/guru/zoroark/shedinja/koin2/TestKoinIntegration.kt
+++ b/shedinja-koin-v2/src/test/kotlin/guru/zoroark/shedinja/koin2/TestKoinIntegration.kt
@@ -12,6 +12,7 @@ import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import org.koin.core.context.startKoin
 import org.koin.core.context.stopKoin
+import org.koin.core.qualifier.named
 import org.koin.dsl.module
 import kotlin.test.assertEquals
 
@@ -21,66 +22,90 @@ class TestKoinIntegration {
 
     interface IdentityRetriever {
         fun koinGetAIdentity(): String
+        fun koinGetA2Identity(): String
         fun koinComponentAIdentity(): String
+        fun koinComponentA2Identity(): String
         fun shedinjaAIdentity(): String
+        fun shedinjaA2Identity(): String
     }
 
-    class KoinGetA {
-        val identity = "I am KoinGetA"
+    class KoinGetA(str: String = "") {
+        val identity = "I am KoinGetA$str"
     }
 
     class KoinGetB(
         private val koinGetA: KoinGetA,
+        private val koinGetA2: KoinGetA,
         private val koinComponentA: KoinComponentA,
-        private val shedinjaA: ShedinjaA
+        private val koinComponentA2: KoinComponentA,
+        private val shedinjaA: ShedinjaA,
+        private val shedinjaA2: ShedinjaA
     ) : IdentityRetriever {
         override fun koinGetAIdentity() = koinGetA.identity + " via KoinGetB"
+        override fun koinGetA2Identity() = koinGetA2.identity + " via KoinGetB"
         override fun koinComponentAIdentity() = koinComponentA.identity + " via KoinGetB"
+        override fun koinComponentA2Identity() = koinComponentA2.identity + " via KoinGetB"
         override fun shedinjaAIdentity() = shedinjaA.identity + " via KoinGetB"
+        override fun shedinjaA2Identity() = shedinjaA2.identity + " via KoinGetB"
     }
 
-    class KoinComponentA : KoinComponent {
-        val identity = "I am KoinComponentA"
+    class KoinComponentA(str: String = "") : KoinComponent {
+        val identity = "I am KoinComponentA$str"
     }
 
     class KoinComponentB: KoinComponent, IdentityRetriever {
         private val koinGetA: KoinGetA by inject()
+        private val koinGetA2: KoinGetA by inject(named("GA2"))
         private val koinComponentA: KoinComponentA by inject()
+        private val koinComponentA2: KoinComponentA by inject(named("CA2"))
         private val shedinjaA: ShedinjaA by inject()
+        private val shedinjaA2: ShedinjaA by inject(named("SA2"))
 
         override fun koinGetAIdentity() = koinGetA.identity + " via KoinComponentB"
+        override fun koinGetA2Identity() = koinGetA2.identity + " via KoinComponentB"
         override fun koinComponentAIdentity() = koinComponentA.identity + " via KoinComponentB"
+        override fun koinComponentA2Identity() = koinComponentA2.identity + " via KoinComponentB"
         override fun shedinjaAIdentity() = shedinjaA.identity + " via KoinComponentB"
+        override fun shedinjaA2Identity() = shedinjaA2.identity + " via KoinComponentB"
     }
 
-    class ShedinjaA {
-        val identity = "I am ShedinjaA"
+    class ShedinjaA(str: String = "") {
+        val identity = "I am ShedinjaA$str"
     }
 
     class ShedinjaB(scope: InjectionScope): IdentityRetriever {
         private val koinGetA: KoinGetA by scope()
+        private val koinGetA2: KoinGetA by scope(guru.zoroark.shedinja.environment.named("GA2"))
         private val koinComponentA: KoinComponentA by scope()
+        private val koinComponentA2: KoinComponentA by scope(guru.zoroark.shedinja.environment.named("CA2"))
         private val shedinjaA: ShedinjaA by scope()
+        private val shedinjaA2: ShedinjaA by scope(guru.zoroark.shedinja.environment.named("SA2"))
 
         override fun koinGetAIdentity() = koinGetA.identity + " via ShedinjaB"
+        override fun koinGetA2Identity() = koinGetA2.identity + " via ShedinjaB"
         override fun koinComponentAIdentity() = koinComponentA.identity + " via ShedinjaB"
+        override fun koinComponentA2Identity() = koinComponentA2.identity + " via ShedinjaB"
         override fun shedinjaAIdentity() = shedinjaA.identity + " via ShedinjaB"
+        override fun shedinjaA2Identity() = shedinjaA2.identity + " via ShedinjaB"
     }
 
     @Test
     fun `Test shedinja integration`() {
         val shedinja = shedinjaModule {
-            put(::ShedinjaA)
+            put { ShedinjaA() }
+            put(guru.zoroark.shedinja.environment.named("SA2")) { ShedinjaA("2") }
             put(::ShedinjaB)
         }
 
         val koinGet = module {
             single { KoinGetA() }
-            single { KoinGetB(get(), get(), get()) }
+            single(named("GA2")) { KoinGetA("2") }
+            single { KoinGetB(get(), get(named("GA2")), get(), get(named("CA2")), get(), get(named("SA2"))) }
         }
 
         val koinComponent = module {
             single { KoinComponentA() }
+            single(named("CA2")) { KoinComponentA("2") }
             single { KoinComponentB() }
         }
 
@@ -98,8 +123,11 @@ class TestKoinIntegration {
 
         for ((name, obj) in retrievers) {
             assertEquals("I am KoinGetA via $name", obj.koinGetAIdentity())
+            assertEquals("I am KoinGetA2 via $name", obj.koinGetA2Identity())
             assertEquals("I am KoinComponentA via $name", obj.koinComponentAIdentity())
+            assertEquals("I am KoinComponentA2 via $name", obj.koinComponentA2Identity())
             assertEquals("I am ShedinjaA via $name", obj.shedinjaAIdentity())
+            assertEquals("I am ShedinjaA2 via $name", obj.shedinjaA2Identity())
         }
 
         stopKoin()

--- a/shedinja-koin-v3/build.gradle
+++ b/shedinja-koin-v3/build.gradle
@@ -1,0 +1,9 @@
+plugins {
+    id 'shedinja.kotlin-lib-conventions'
+}
+
+dependencies {
+    api project(":shedinja")
+    api libs.koin.v3
+    // implementation libs.kotlin.reflect
+}

--- a/shedinja-koin-v3/src/main/kotlin/guru/zoroark/shedinja/koin3/KoinIntegration.kt
+++ b/shedinja-koin-v3/src/main/kotlin/guru/zoroark/shedinja/koin3/KoinIntegration.kt
@@ -1,0 +1,128 @@
+package guru.zoroark.shedinja.koin3
+
+import guru.zoroark.shedinja.dsl.ShedinjaDsl
+import guru.zoroark.shedinja.environment.*
+import org.koin.core.KoinApplication
+import org.koin.core.definition.BeanDefinition
+import org.koin.core.definition.IndexKey
+import org.koin.core.definition.Kind
+import org.koin.core.definition.indexKey
+import org.koin.core.instance.InstanceFactory
+import org.koin.core.instance.SingleInstanceFactory
+import org.koin.core.module.Module
+import org.koin.core.qualifier.Qualifier
+import org.koin.core.qualifier.StringQualifier
+import org.koin.core.registry.ScopeRegistry
+import org.koin.dsl.module
+import kotlin.reflect.KProperty
+
+/**
+ * Adds the given Shedinja modules to this Koin application. This process is done transparently for you: you can inject
+ * components from Koin modules into Shedinja modules and vice versa.
+ *
+ * See [toKoinModule] for more information.
+ */
+@ShedinjaDsl
+fun KoinApplication.shedinjaModules(vararg modules: InjectableModule) {
+    modules(modules.map { it.toKoinModule(this@shedinjaModules) })
+}
+
+/**
+ * Turns this Shedinja module into a module that is uses the given Koin application for processing cross-framework
+ * injections.
+ *
+ * Internally, Shedinja injects the components created in this module into the module (thus making Shedinja components
+ * injectable from Koin) and supplies an [InjectionScope] that is backed by the given Koin application object to the
+ * Shedinja object suppliers (thus making Koin components injectable from Koin).
+ *
+ * **NOTE:** This feature abuses the fact that `internal` properties annotated with `@PublishedApi` are effectively
+ * public and can be accessed via reflection without any use of `setAccessible`. Such properties are byte-code public,
+ * although the compiler will raise an error, thus making reflection needed.
+ */
+fun InjectableModule.toKoinModule(app: KoinApplication): Module = module {
+    val definitions =
+        this.reflectiveAccessTo<Module, HashMap<IndexKey, InstanceFactory<*>>>("getMappings")
+    val moduleRootScope =
+        ScopeRegistry.Companion.reflectiveAccessTo<ScopeRegistry.Companion, Qualifier>(
+            "getRootScopeQualifier"
+        )
+    declarations.forEach { declaration ->
+        val koinQualifier = declaration.identifier.qualifier.toKoinQualifier()
+        val indexKey = indexKey(
+            declaration.identifier.kclass,
+            koinQualifier,
+            moduleRootScope
+        )
+        definitions[indexKey] = SingleInstanceFactory(
+            BeanDefinition(
+                moduleRootScope,
+                declaration.identifier.kclass,
+                koinQualifier, {
+                    declaration.supplier(
+                        ScopedContext(
+                            KoinApplicationBackedScope(app)
+                        )
+                    )
+                },
+                Kind.Singleton
+            )
+        )
+    }
+}
+
+/**
+ * Interface for Shedinja qualifier that provides a way of translating them to Koin v2 qualifiers.
+ *
+ * Note that:
+ *
+ * - This should only be implemented for custom qualifiers in applications that require the Shedinja-Koin
+ * - Internally, [EmptyQualifier] and [NameQualifier] can already be converted to Koin's qualifiers.
+ * - There is a naming conflict between `guru.zoroark.shedinja.environment.Qualifier` and
+ * `org.koin.core.qualifier.Qualifier` which may cause issues. Consider using
+ * [the `as` keyword](https://kotlinlang.org/docs/packages.html#imports) when importing these classes for solving this
+ * conflict.
+ */
+interface KoinCompatibleQualifier :
+    guru.zoroark.shedinja.environment.Qualifier {
+    /**
+     * Convert this qualifier to a Koin qualifier.
+     */
+    fun toKoinQualifier(): Qualifier
+}
+
+private fun guru.zoroark.shedinja.environment.Qualifier.toKoinQualifier(): Qualifier? =
+    when (this) {
+        is KoinCompatibleQualifier -> toKoinQualifier()
+        EmptyQualifier -> null
+        is NameQualifier -> StringQualifier(name)
+        else -> error(
+            """
+            The following Shedinja qualifier cannot be converted to Koin's qualifier type: ${this.javaClass.name}.
+            You can resolve this by making ${this.javaClass.name} implement the 'KoinCompatibleQualifier` interface.
+            """.trimIndent()
+        )
+    }
+
+private class KoinApplicationBackedScope(private val app: KoinApplication) :
+    InjectionScope {
+    override fun <T : Any> inject(what: Identifier<T>): Injector<T> =
+        KoinApplicatedBackedInjector(what, app)
+}
+
+private class KoinApplicatedBackedInjector<T : Any>(
+    private val identifier: Identifier<T>,
+    private val app: KoinApplication
+) :
+    Injector<T> {
+    private val value: T by lazy {
+        app.koin.get(identifier.kclass, identifier.qualifier.toKoinQualifier())
+    }
+
+    override fun getValue(thisRef: Any?, property: KProperty<*>): T = value
+}
+
+private inline fun <reified R, reified T> R.reflectiveAccessTo(propertyName: String): T {
+    return R::class.java.getMethod(propertyName).invoke(this) as T
+}
+
+

--- a/shedinja-koin-v3/src/test/kotlin/guru/zoroark/shedinja/koin3/TestKoinIntegration.kt
+++ b/shedinja-koin-v3/src/test/kotlin/guru/zoroark/shedinja/koin3/TestKoinIntegration.kt
@@ -1,0 +1,130 @@
+package guru.zoroark.shedinja.koin3
+
+import guru.zoroark.shedinja.dsl.put
+import guru.zoroark.shedinja.dsl.shedinjaModule
+import guru.zoroark.shedinja.environment.InjectionScope
+import guru.zoroark.shedinja.environment.invoke
+import org.junit.jupiter.api.Test
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.core.qualifier.named
+import org.koin.dsl.module
+import kotlin.test.assertEquals
+
+class TestKoinIntegration {
+
+    interface IdentityRetriever {
+        fun koinGetAIdentity(): String
+        fun koinGetA2Identity(): String
+        fun koinComponentAIdentity(): String
+        fun koinComponentA2Identity(): String
+        fun shedinjaAIdentity(): String
+        fun shedinjaA2Identity(): String
+    }
+
+    class KoinGetA(str: String = "") {
+        val identity = "I am KoinGetA$str"
+    }
+
+    class KoinGetB(
+        private val koinGetA: KoinGetA,
+        private val koinGetA2: KoinGetA,
+        private val koinComponentA: KoinComponentA,
+        private val koinComponentA2: KoinComponentA,
+        private val shedinjaA: ShedinjaA,
+        private val shedinjaA2: ShedinjaA
+    ) : IdentityRetriever {
+        override fun koinGetAIdentity() = koinGetA.identity + " via KoinGetB"
+        override fun koinGetA2Identity() = koinGetA2.identity + " via KoinGetB"
+        override fun koinComponentAIdentity() = koinComponentA.identity + " via KoinGetB"
+        override fun koinComponentA2Identity() = koinComponentA2.identity + " via KoinGetB"
+        override fun shedinjaAIdentity() = shedinjaA.identity + " via KoinGetB"
+        override fun shedinjaA2Identity() = shedinjaA2.identity + " via KoinGetB"
+    }
+
+    class KoinComponentA(str: String = "") : KoinComponent {
+        val identity = "I am KoinComponentA$str"
+    }
+
+    class KoinComponentB: KoinComponent, IdentityRetriever {
+        private val koinGetA: KoinGetA by inject()
+        private val koinGetA2: KoinGetA by inject(named("GA2"))
+        private val koinComponentA: KoinComponentA by inject()
+        private val koinComponentA2: KoinComponentA by inject(named("CA2"))
+        private val shedinjaA: ShedinjaA by inject()
+        private val shedinjaA2: ShedinjaA by inject(named("SA2"))
+
+        override fun koinGetAIdentity() = koinGetA.identity + " via KoinComponentB"
+        override fun koinGetA2Identity() = koinGetA2.identity + " via KoinComponentB"
+        override fun koinComponentAIdentity() = koinComponentA.identity + " via KoinComponentB"
+        override fun koinComponentA2Identity() = koinComponentA2.identity + " via KoinComponentB"
+        override fun shedinjaAIdentity() = shedinjaA.identity + " via KoinComponentB"
+        override fun shedinjaA2Identity() = shedinjaA2.identity + " via KoinComponentB"
+    }
+
+    class ShedinjaA(str: String = "") {
+        val identity = "I am ShedinjaA$str"
+    }
+
+    class ShedinjaB(scope: InjectionScope): IdentityRetriever {
+        private val koinGetA: KoinGetA by scope()
+        private val koinGetA2: KoinGetA by scope(guru.zoroark.shedinja.environment.named("GA2"))
+        private val koinComponentA: KoinComponentA by scope()
+        private val koinComponentA2: KoinComponentA by scope(guru.zoroark.shedinja.environment.named("CA2"))
+        private val shedinjaA: ShedinjaA by scope()
+        private val shedinjaA2: ShedinjaA by scope(guru.zoroark.shedinja.environment.named("SA2"))
+
+        override fun koinGetAIdentity() = koinGetA.identity + " via ShedinjaB"
+        override fun koinGetA2Identity() = koinGetA2.identity + " via ShedinjaB"
+        override fun koinComponentAIdentity() = koinComponentA.identity + " via ShedinjaB"
+        override fun koinComponentA2Identity() = koinComponentA2.identity + " via ShedinjaB"
+        override fun shedinjaAIdentity() = shedinjaA.identity + " via ShedinjaB"
+        override fun shedinjaA2Identity() = shedinjaA2.identity + " via ShedinjaB"
+    }
+
+    @Test
+    fun `Test shedinja integration`() {
+        val shedinja = shedinjaModule {
+            put { ShedinjaA() }
+            put(guru.zoroark.shedinja.environment.named("SA2")) { ShedinjaA("2") }
+            put(TestKoinIntegration::ShedinjaB)
+        }
+
+        val koinGet = module {
+            single { KoinGetA() }
+            single(named("GA2")) { KoinGetA("2") }
+            single { KoinGetB(get(), get(named("GA2")), get(), get(named("CA2")), get(), get(named("SA2"))) }
+        }
+
+        val koinComponent = module {
+            single { KoinComponentA() }
+            single(named("CA2")) { KoinComponentA("2") }
+            single { KoinComponentB() }
+        }
+
+        val koin = startKoin {
+            modules(koinGet, koinComponent)
+
+            shedinjaModules(shedinja)
+        }.koin
+
+        val retrievers = mapOf(
+            "KoinGetB" to koin.get<KoinGetB>(),
+            "KoinComponentB" to koin.get<KoinComponentB>(),
+            "ShedinjaB" to koin.get<ShedinjaB>()
+        )
+
+        for ((name, obj) in retrievers) {
+            assertEquals("I am KoinGetA via $name", obj.koinGetAIdentity())
+            assertEquals("I am KoinGetA2 via $name", obj.koinGetA2Identity())
+            assertEquals("I am KoinComponentA via $name", obj.koinComponentAIdentity())
+            assertEquals("I am KoinComponentA2 via $name", obj.koinComponentA2Identity())
+            assertEquals("I am ShedinjaA via $name", obj.shedinjaAIdentity())
+            assertEquals("I am ShedinjaA2 via $name", obj.shedinjaA2Identity())
+        }
+
+        stopKoin()
+    }
+}

--- a/shedinja-test/src/main/kotlin/guru/zoroark/shedinja/test/ShedinjaCheck.kt
+++ b/shedinja-test/src/main/kotlin/guru/zoroark/shedinja/test/ShedinjaCheck.kt
@@ -183,7 +183,7 @@ val complete = IndividualCheck { modules ->
         .takeIf { it.isNotEmpty() }
     if (requirementToMissingDependency != null) {
         val message = requirementToMissingDependency.asSequence()
-            .flatMap { (requestor, missingDependencies) -> missingDependencies.map { it to requestor } }
+            .flatMap { (requester, missingDependencies) -> missingDependencies.map { it to requester } }
             .associateByMultiPair()
             .entries.joinToString(
                 prefix = "Some dependencies were not found. Make sure they are present within your module definitions.\n",
@@ -191,7 +191,7 @@ val complete = IndividualCheck { modules ->
             ) { (k, v) ->
                 v.joinToString(
                     prefix = "--> $k not found\n    Requested by:\n", separator = "\n"
-                ) { requestor -> "    --> $requestor" }
+                ) { requester -> "    --> $requester" }
             }
         throw ShedinjaCheckException(message)
     }
@@ -207,9 +207,9 @@ val complete = IndividualCheck { modules ->
 }
 
 private fun <K, V> Sequence<Pair<K, V>>.associateByMultiPair(): Map<K, List<V>> =
-    fold(mutableMapOf<K, MutableList<V>>()) { map, (missing, requestor) ->
+    fold(mutableMapOf<K, MutableList<V>>()) { map, (missing, requester) ->
         map.compute(missing) { _, original ->
-            (original ?: mutableListOf()).apply { add(requestor) }
+            (original ?: mutableListOf()).apply { add(requester) }
         }
         map
     }

--- a/shedinja/src/main/kotlin/guru/zoroark/shedinja/extensions/InjectableFactory.kt
+++ b/shedinja/src/main/kotlin/guru/zoroark/shedinja/extensions/InjectableFactory.kt
@@ -1,0 +1,130 @@
+package guru.zoroark.shedinja.extensions
+
+import guru.zoroark.shedinja.dsl.ContextBuilderDsl
+import guru.zoroark.shedinja.dsl.ShedinjaDsl
+import guru.zoroark.shedinja.dsl.put
+import guru.zoroark.shedinja.environment.InjectionScope
+import guru.zoroark.shedinja.environment.Qualifier
+import guru.zoroark.shedinja.environment.invoke
+import kotlin.properties.ReadOnlyProperty
+import kotlin.reflect.KClass
+import kotlin.reflect.KProperty
+
+/**
+ * An injectable component whose job is to create components of the same type repeatably.
+ */
+fun interface InjectableFactory<T : Any> {
+    /**
+     * Create the component from the given requesting object (i.e. the object that asked for the injection).
+     */
+    fun make(requestor: Any): T
+}
+
+// Environment management
+
+/**
+ * Qualifier specifically designed for [InjectableFactory]. Due to type erasure, all injectable factories are identified
+ * as `InjectableFactory` by default, without any type parameter, leading to duplication errors since their identifiers
+ * would all be the same. This qualifier lifts this ambiguity by providing the actual type of the output for
+ * identification purposes.
+ *
+ * @property outputs The output type of this factory, i.e. the generic type of [InjectableFactory].
+ */
+data class InjectableFactoryOutputTypeQualifier(val outputs: KClass<*>) : Qualifier {
+    override fun toString(): String = "Factory with output $outputs"
+}
+
+/**
+ * Creates an [InjectableFactoryOutputTypeQualifier] with the given output as a parameter.
+ */
+@ShedinjaDsl
+fun outputs(output: KClass<*>) = InjectableFactoryOutputTypeQualifier(output)
+
+// Creation in module
+
+/**
+ * Allows to put a factory within the module or environment.
+ *
+ * A factory is the opposite of a singleton: instead of a single instance being created once and shared by all other
+ * services (also known as a singleton), factories
+ */
+@ShedinjaDsl
+inline fun <reified T : Any> ContextBuilderDsl.putFactory(crossinline block: (Any) -> T) {
+    put(outputs(T::class)) { InjectableFactory { block(it) } }
+}
+
+// Injection DSL
+
+/**
+ * Initial DSL marker object for creating factory injection sites.
+ *
+ * @property ofObject The original caller for the factory creation. This is then passed in [InjectableFactory.make]'s
+ * argument.
+ */
+class FactoryDsl(val ofObject: Any)
+
+/**
+ * Initiates the DSL for injecting factory-made objects. Usage is `factory from scope`.
+ */
+@ShedinjaDsl
+val Any.factory
+    get() = FactoryDsl(this)
+
+/**
+ * DSL for injecting factory-made objects. Usage is `faactory from scope`.
+ */
+@ShedinjaDsl
+inline infix fun <R, reified T : Any> FactoryDsl.from(scope: InjectionScope): ReadOnlyProperty<R, T> =
+    SynchronizedLazyPropertyWrapper(
+        scope<InjectableFactory<T>>(outputs(T::class)) wrapIn { it.make(ofObject) }
+    )
+
+// Utilities
+
+/**
+ * Utility function that wraps a given property using the given wrapper. This is useful when you want to transform the
+ * output of a property in some way.
+ *
+ * Note that this doesn't cache the result in any way. The `mapper` is ran every time the property is `get`ed. You may
+ * want to wrap it further with [SynchronizedLazyPropertyWrapper] to make it only run once.
+ */
+infix fun <T, V, R> ReadOnlyProperty<T, V>.wrapIn(mapper: (V) -> R): WrappedReadOnlyProperty<T, V, R> =
+    WrappedReadOnlyProperty(this, mapper)
+
+/**
+ * Wraps a property and maps its result using the given mapper.
+ */
+class WrappedReadOnlyProperty<T, V, R>(
+    private val original: ReadOnlyProperty<T, V>,
+    private val mapper: (V) -> R
+) : ReadOnlyProperty<T, R> {
+    override fun getValue(thisRef: T, property: KProperty<*>): R =
+        mapper(original.getValue(thisRef, property))
+}
+
+/**
+ * Similar to `lazy { }` but uses a property instead of a lambda for building. Inspired by the `SYNCHRONIZED` lazy
+ * implementation.
+ */
+class SynchronizedLazyPropertyWrapper<T, V : Any>(private val wrappedProperty: ReadOnlyProperty<T, V>) : ReadOnlyProperty<T, V> {
+    @Volatile private var value: V? = null
+
+    override fun getValue(thisRef: T, property: KProperty<*>): V {
+        val valueNow = value
+        if (valueNow != null) {
+            return valueNow
+        }
+
+        return synchronized(this) {
+            val valueNow2 = value
+            if (valueNow2 != null) {
+                valueNow2
+            } else {
+                val newValue = wrappedProperty.getValue(thisRef, property)
+                value = newValue
+                newValue
+            }
+
+        }
+    }
+}

--- a/shedinja/src/main/kotlin/guru/zoroark/shedinja/extensions/InjectableFactory.kt
+++ b/shedinja/src/main/kotlin/guru/zoroark/shedinja/extensions/InjectableFactory.kt
@@ -17,7 +17,7 @@ fun interface InjectableFactory<T : Any> {
     /**
      * Create the component from the given requesting object (i.e. the object that asked for the injection).
      */
-    fun make(requestor: Any): T
+    fun make(requester: Any): T
 }
 
 // Environment management
@@ -71,7 +71,7 @@ val Any.factory
     get() = FactoryDsl(this)
 
 /**
- * DSL for injecting factory-made objects. Usage is `faactory from scope`.
+ * DSL for injecting factory-made objects. Usage is `factory from scope`.
  */
 @ShedinjaDsl
 inline infix fun <R, reified T : Any> FactoryDsl.from(scope: InjectionScope): ReadOnlyProperty<R, T> =

--- a/shedinja/src/test/kotlin/guru/zoroark/shedinja/PostInjectActionTest.kt
+++ b/shedinja/src/test/kotlin/guru/zoroark/shedinja/PostInjectActionTest.kt
@@ -1,0 +1,172 @@
+package guru.zoroark.shedinja
+
+import guru.zoroark.shedinja.dsl.ContextBuilderDsl
+import guru.zoroark.shedinja.dsl.ShedinjaDsl
+import guru.zoroark.shedinja.dsl.put
+import guru.zoroark.shedinja.dsl.shedinja
+import guru.zoroark.shedinja.dsl.shedinjaModule
+import guru.zoroark.shedinja.environment.InjectionScope
+import guru.zoroark.shedinja.environment.Qualifier
+import guru.zoroark.shedinja.environment.get
+import guru.zoroark.shedinja.environment.invoke
+import org.junit.jupiter.api.Test
+import kotlin.properties.ReadOnlyProperty
+import kotlin.reflect.KClass
+import kotlin.reflect.KProperty
+import kotlin.test.assertEquals
+
+// TODO Put the interesting stuff in main, not in tests
+
+fun interface InjectableFactory<T : Any> {
+    fun make(requestor: Any): T
+}
+
+class PostInjectActionTest {
+    interface WhatIsYourA {
+        val name: String
+        fun whatIsYourA(): String
+    }
+
+    interface WhatIsYourLogger {
+        val loggerName: String
+        fun whatIsYourLogger(): String
+    }
+
+    class A(who: String) {
+        val identity = "I am $who's A"
+    }
+
+    class Logger(origin: String) {
+        val identity = "I am $origin's Logger"
+    }
+
+    class B(scope: InjectionScope) : WhatIsYourA, WhatIsYourLogger {
+        override val name = "B"
+        override val loggerName = "log.B"
+        private val a: A by factory from scope
+        private val logger: Logger by factory from scope
+
+        override fun whatIsYourA(): String = "My A is ${a.identity}"
+        override fun whatIsYourLogger(): String = "My Logger is ${logger.identity}"
+    }
+
+    class C(scope: InjectionScope) : WhatIsYourA, WhatIsYourLogger {
+        override val name = "C"
+        override val loggerName = "log.C"
+        private val a: A by factory from scope
+        private val logger: Logger by factory from scope
+
+        override fun whatIsYourA(): String = "My A is ${a.identity}"
+        override fun whatIsYourLogger(): String = "My Logger is ${logger.identity}"
+    }
+
+    class D(scope: InjectionScope) : WhatIsYourA {
+        override val name = "D"
+        private val a: A by factory from scope
+
+        override fun whatIsYourA(): String = "My A is ${a.identity}"
+    }
+
+    class E(scope: InjectionScope) : WhatIsYourLogger {
+        override val loggerName  = "log.E"
+        private val logger: Logger by factory from scope
+
+        override fun whatIsYourLogger(): String = "My Logger is ${logger.identity}"
+    }
+
+    @Test
+    fun `Test factory system`() {
+        val module = shedinjaModule {
+            putFactory { requestor ->
+                A((requestor as WhatIsYourA).name)
+            }
+            put(::B)
+            put(::C)
+            put(::D)
+        }
+        val env = shedinja { put(module) }
+
+        mapOf(
+            env.get<B>() to "My A is I am B's A",
+            env.get<C>() to "My A is I am C's A",
+            env.get<D>() to "My A is I am D's A"
+        ).forEach { (k, v) ->
+            assertEquals(k.whatIsYourA(), v)
+        }
+    }
+
+    @Test
+    fun `Test factory with double stuff system`() {
+        val module = shedinjaModule {
+            putFactory { requestor ->
+                A((requestor as WhatIsYourA).name)
+            }
+            putFactory { requestor ->
+                Logger((requestor as WhatIsYourLogger).loggerName)
+            }
+
+            put(::B)
+            put(::C)
+            put(::D)
+            put(::E)
+        }
+        val env = shedinja { put(module) }
+
+        mapOf(
+            env.get<B>() to "My A is I am B's A",
+            env.get<C>() to "My A is I am C's A",
+            env.get<D>() to "My A is I am D's A"
+        ).forEach { (k, v) ->
+            assertEquals(k.whatIsYourA(), v)
+        }
+
+        mapOf(
+            env.get<B>() to "My Logger is I am log.B's Logger",
+            env.get<C>() to "My Logger is I am log.C's Logger",
+            env.get<E>() to "My Logger is I am log.E's Logger"
+        ).forEach { (k, v) ->
+            assertEquals(k.whatIsYourLogger(), v)
+        }
+    }
+}
+
+// Environment management
+
+data class InjectableFactoryOutputTypeQualifier(val outputs: KClass<*>) : Qualifier {
+    override fun toString(): String = "Factory with output $outputs"
+}
+
+@ShedinjaDsl
+fun outputs(output: KClass<*>) = InjectableFactoryOutputTypeQualifier(output)
+
+// Creation in module
+
+@ShedinjaDsl
+inline fun <reified T : Any> ContextBuilderDsl.putFactory(crossinline block: (Any) -> T) {
+    put(outputs(T::class)) { InjectableFactory { block(it) } }
+}
+
+// Injection DSL
+
+class FactoryDsl(val ofObject: Any)
+
+@ShedinjaDsl
+val Any.factory
+    get() = FactoryDsl(this)
+
+@ShedinjaDsl
+inline infix fun <R, reified T : Any> FactoryDsl.from(scope: InjectionScope): ReadOnlyProperty<R, T> =
+    scope<InjectableFactory<T>>(outputs(T::class)) wrapIn { it.make(ofObject) }
+
+// Utilities
+
+infix fun <T, V, R> ReadOnlyProperty<T, V>.wrapIn(mapper: (V) -> R): WrappedReadOnlyProperty<T, V, R> =
+    WrappedReadOnlyProperty(this, mapper)
+
+class WrappedReadOnlyProperty<T, V, R>(
+    private val original: ReadOnlyProperty<T, V>,
+    private val mapper: (V) -> R
+) : ReadOnlyProperty<T, R> {
+    override fun getValue(thisRef: T, property: KProperty<*>): R =
+        mapper(original.getValue(thisRef, property))
+}

--- a/shedinja/src/test/kotlin/guru/zoroark/shedinja/PostInjectActionTest.kt
+++ b/shedinja/src/test/kotlin/guru/zoroark/shedinja/PostInjectActionTest.kt
@@ -45,7 +45,8 @@ class PostInjectActionTest {
         private val logger: Logger by factory from scope
 
         override fun whatIsYourA(): String = "My A is ${a.identity}"
-        override fun whatIsYourLogger(): String = "My Logger is ${logger.identity}"
+        override fun whatIsYourLogger(): String =
+            "My Logger is ${logger.identity}"
     }
 
     @LoggerName("Coconut")
@@ -56,7 +57,8 @@ class PostInjectActionTest {
         private val logger: Logger by factory from scope
 
         override fun whatIsYourA(): String = "My A is ${a.identity}"
-        override fun whatIsYourLogger(): String = "My Logger is ${logger.identity}"
+        override fun whatIsYourLogger(): String =
+            "My Logger is ${logger.identity}"
     }
 
     class D(scope: InjectionScope) : WhatIsYourA {
@@ -68,19 +70,20 @@ class PostInjectActionTest {
 
     @LoggerName("Markiplier") // Yeah, it's a dead meme, I know.
     class E(scope: InjectionScope) : WhatIsYourLogger {
-        override val loggerName  = "log.E"
+        override val loggerName = "log.E"
         private val logger: Logger by factory from scope
 
-        override fun whatIsYourLogger(): String = "My Logger is ${logger.identity}"
+        override fun whatIsYourLogger(): String =
+            "My Logger is ${logger.identity}"
     }
 
     @Test
     fun `Test factory system`() {
         var factoryCallCount = 0
         val module = shedinjaModule {
-            putFactory { requestor ->
+            putFactory { requester ->
                 factoryCallCount++
-                A((requestor as WhatIsYourA).name)
+                A((requester as WhatIsYourA).name)
             }
             put(::B)
             put(::C)
@@ -99,9 +102,12 @@ class PostInjectActionTest {
             }
 
         }
-        assertEquals(3, factoryCallCount, "Factory function must be called exactly three times")
+        assertEquals(
+            3,
+            factoryCallCount,
+            "Factory function must be called exactly three times"
+        )
     }
-
 
     private val KClass<*>.loggerName: String
         get() = findAnnotation<LoggerName>()?.name ?: "(no name)"
@@ -111,13 +117,16 @@ class PostInjectActionTest {
         var aFactoryCallCount = 0
         var loggerFactoryCallCount = 0
         val module = shedinjaModule {
-            putFactory { requestor ->
+            putFactory { requester ->
                 aFactoryCallCount++
-                A((requestor as WhatIsYourA).name)
+                A((requester as WhatIsYourA).name)
             }
-            putFactory { requestor ->
+            putFactory { requester ->
                 loggerFactoryCallCount++
-                Logger((requestor as WhatIsYourLogger).loggerName, requestor::class.loggerName)
+                Logger(
+                    (requester as WhatIsYourLogger).loggerName,
+                    requester::class.loggerName
+                )
             }
 
             put(::B)
@@ -146,7 +155,11 @@ class PostInjectActionTest {
             repeat(3) { assertEquals(k.whatIsYourLogger(), v) }
         }
 
-        assertEquals(3, loggerFactoryCallCount, "Incorrect nb of calls to logger factory")
+        assertEquals(
+            3,
+            loggerFactoryCallCount,
+            "Incorrect nb of calls to logger factory"
+        )
         assertEquals(3, aFactoryCallCount, "Incorrect nb of calls to A factory")
     }
 }


### PR DESCRIPTION
The goal of this PR is to provide interoperability with Koin applications and modules. Specifically:

* [X] Being able to add Shedinja modules to Koin apps.
    * [x] Properly convert `named` qualifiers from Shedinja to Koin
* [ ] Being able to add Koin modules to Shedinja apps.
    * *Much* harder as Koin's system wasn't really intended for that. Would probably involve transforming Koin definitions into Shedinja declarations and providing a way to resolve components early right from an `InjectionScope`... It's kind of a mess :/ Koin is based *a lot* around eager injection *at the instanciation step*, which is something Shedinja was specifically made to avoid. So either we can just only support KoinComponent-based modules, or we'll see...